### PR TITLE
Support pdb format (input)

### DIFF
--- a/openbabel-sys/build.rs
+++ b/openbabel-sys/build.rs
@@ -115,6 +115,7 @@ fn main() {
         .file("openbabel/src/formats/orcaformat.cpp")
         .file("openbabel/src/formats/siestaformat.cpp")
         .file("openbabel/src/formats/mdlformat.cpp")
+        .file("openbabel/src/formats/pdbformat.cpp")
         .file("openbabel/src/alias.cpp")
         .file("openbabel/src/mcdlutil.cpp")
         .file("src/wrapper.cpp")

--- a/src/io/formats.rs
+++ b/src/io/formats.rs
@@ -57,6 +57,8 @@ pub enum InputFormat {
     /// SDF format
     sd,
     sdf,
+    /// PDB format
+    pdb,
 }
 
 #[derive(Eq, PartialEq, Display, Debug, EnumString)]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -108,4 +108,23 @@ Au  0.00000000  3.33130605  2.35558910".to_string();
         test_string(&conv);
         test_file(&conv);
     }
+
+    fn test_pdb(conv: &conversion::Conversion) {
+        let path_ref =
+            std::path::Path::new("./openbabel-sys/openbabel/test/files/00T_ideal.pdb").as_ref();
+        let format = formats::InputFormat::pdb;
+        let file_for_mol = FileForMol { path_ref, format };
+        let mol = file_for_mol
+            .to_mol(conv)
+            .expect("unable to create Molecule from file");
+        assert!(mol.is_valid());
+        assert_eq!(mol.num_atoms(), 22);
+        assert_eq!(mol.num_bonds(), 22);
+    }
+
+    #[test]
+    fn test_file_for_pdb() {
+        let conv = conversion::Conversion::new();
+        test_pdb(&conv);
+    }
 }


### PR DESCRIPTION
Added pdb support as discussed in https://github.com/rogerwq/openbabel-rust/issues/11

Added as well a test, which is passing, not sure about consistency with the other test though, you tell me?